### PR TITLE
Fixed update clean function

### DIFF
--- a/src/utils/threads/update.lua
+++ b/src/utils/threads/update.lua
@@ -32,16 +32,16 @@ end
 
 function recursiveGetDirectoryItems(folder, list)
     list = list or {}
-	for i, filename in ipairs(love.filesystem.getDirectoryItems(folder)) do
-		local filePath = folder..'/'..filename
-		local info = love.filesystem.getInfo(filePath)
-		if info and info.type == 'file' then
+    for i, filename in ipairs(love.filesystem.getDirectoryItems(folder)) do
+        local filePath = folder..'/'..filename
+        local info = love.filesystem.getInfo(filePath)
+        if info and info.type == 'file' then
             table.insert(list, filePath)
-		elseif info and info.type == 'directory' then
+        elseif info and info.type == 'directory' then
             recursiveGetDirectoryItems(filePath, list)
-		end
-	end
-	return list
+        end
+    end
+    return list
 end
 
 function rename(path, newpath)

--- a/src/utils/threads/update.lua
+++ b/src/utils/threads/update.lua
@@ -26,7 +26,7 @@ for folder, file, hash, size in (fileinfo):gmatch'([^\r\n]+)\\([^\r\n\\]+),0x([0
         end
     end
     if toClean[folder] or toClean[folder:match'^[^/\\]*'] then
-        cleanFiles['/'..localPath] = folder
+        cleanFiles['/'..localPath:lower()] = folder
     end
 end
 
@@ -60,8 +60,8 @@ function rename(path, newpath)
 end
 
 for checkFolder, output in pairs(toClean) do
-    for i, path in ipairs(recursiveGetDirectoryItems(writePath..'/'..checkFolder)) do
-        if not cleanFiles[path] then
+    for i, path in ipairs(recursiveGetDirectoryItems('/'..writePath..checkFolder)) do
+        if not cleanFiles[path:lower()] then
             if rename(path, (path:gsub(checkFolder, output, 1))) then
                 checkEmpty[ path:match'(.*)/[^/]*' ] = true
             end


### PR DESCRIPTION
The update 'unsupported file clean' function was case sensitive, and had a slash in the wrong place when in a bound exe.